### PR TITLE
Pass check that options is an object

### DIFF
--- a/server/initialize.js
+++ b/server/initialize.js
@@ -6,7 +6,7 @@
 Meteor.startup(function () {
   if (process.env.INITIALIZE) {
     console.log('Initializing HouseMD users...');
-    Meteor.call("initializeUsers");
+    Meteor.call("initializeUsers", {});
   }
 });
 


### PR DESCRIPTION
When running meteor-on-fhir with INITIALIZE=true, this initialization code was failing due to the check on line 17.